### PR TITLE
feat: add child commerce code webpay plus mall

### DIFF
--- a/app/Http/Controllers/WebpayPlusMallController.php
+++ b/app/Http/Controllers/WebpayPlusMallController.php
@@ -18,7 +18,19 @@ class WebpayPlusMallController extends Controller
 
     public function createMall(Request $request)
     {
-        return view('webpayplus/mall_create');
+        $childCommerceCodeNormal = config('services.transbank.webpay_plus_mall_child_cc');
+        $childCommerceCode3ds = config('services.transbank.webpay_plus_mall_child_3ds');
+
+        $commerceCodeList = [];
+        foreach ($childCommerceCodeNormal as $childNormal){
+            $commerceCodeList[] = ['commerce_code' => $childNormal, 'type_child'=> 'normal'];
+        }
+
+        foreach ($childCommerceCode3ds as $child){
+            $commerceCodeList[] = ['commerce_code' => $child, 'type_child'=> '3DS'];
+        }
+
+        return view('webpayplus/mall_create', compact('commerceCodeList'));
     }
 
     public function createdMallTransaction(Request $request)

--- a/config/services.php
+++ b/config/services.php
@@ -48,7 +48,8 @@ return [
         'webpay_plus_cc' => env('WEBPAY_PLUS_CC'),
         'webpay_plus_api_key' => env('WEBPAY_PLUS_API_KEY'),
         'webpay_plus_mall_cc' => env('WEBPAY_PLUS_MALL_CC'),
-        'webpay_plus_mall_child_cc' => env ('WEBPAY_PLUS_MALL_CHILD_CC'),
+        'webpay_plus_mall_child_cc' => explode(',', env ('WEBPAY_PLUS_MALL_CHILD_CC')),
+        'webpay_plus_mall_child_3ds' => explode(',',env('WEBPAY_PLUS_MALL_CHILD_3DS')),
         'webpay_plus_mall_api_key' => env('WEBPAY_PLUS_MALL_API_KEY'),
 
         'webpay_plus_mall_qr_cc' => env('WEBPAY_PLUS_MALL_QR_CC'),

--- a/resources/views/webpayplus/mall_create.blade.php
+++ b/resources/views/webpayplus/mall_create.blade.php
@@ -6,14 +6,23 @@
     @csrf
 
     @if (app()->environment('production'))
-        <label for="merchant_1_amount">Monto comercio 1</label>
-        <input id="merchant_1_amount" name="detail[0][amount]" value="1000">
+        @foreach($commerceCodeList as $i => $child)
+            @if($child['type_child'] == '3DS')
+                <span> Tienda Piloto 3DS {{$child['commerce_code']}} </span>
+            @else
+                <span> Tienda Normal {{$child['commerce_code']}} </span>
+            @endif
 
-        <label for="merchant_1_commerce_code">Código comercio del comercio #1</label>
-        <input id="merchant_1_commerce_code" name="detail[0][commerce_code]" value="{{ config('services.transbank.webpay_plus_mall_child_cc') }}">
+            <label for="merchant_{{$i}}_amount">Monto comercio</label>
+            <input id="merchant_{{$i}}_amount" name="detail[{{$i}}][amount]" value="1000">
 
-        <label for="merchant_1_buy_order">Orden de compra comercio #1</label>
-        <input id="merchant_1_buy_order" name="detail[0][buy_order]" value="buyorder_{{Str::random(10)}}">
+            <label for="merchant_{{$i}}_commerce_code">Código comercio del comercio</label>
+            <input id="merchant_{{$i}}_commerce_code" name="detail[{{$i}}][commerce_code]" value="{{$child['commerce_code']}}">
+
+            <label for="merchant_{{$i}}_buy_order">Orden de compra comercio</label>
+            <input id="merchant_{{$i}}_buy_order" name="detail[{{$i}}][buy_order]" value="buyorder_{{Str::random(10)}}">
+        @endforeach
+
     @else
         <label for="merchant_1_amount">Monto comercio 1</label>
         <input id="merchant_1_amount" name="detail[0][amount]" value="1000">


### PR DESCRIPTION
This pull request allows the creation of transactions Webpay plus Mall with new child commerce codes for the productive environment.

Changelog:
- Create an array with Webpayplus mall child commerce codes
- Add new method on WebpayPlusMallController to return child commerce codes array to view
- Refactor mall_create view to show form with details to each child commerce code (only for production mode)

![Ejemplos Webpay REST - transbank-sdk-php-webpay-rest-example test](https://github.com/TransbankDevelopers/transbank-sdk-php-webpay-rest-example/assets/16402208/191c3154-53c6-4330-850d-a6e6530e66da)

![Ejemplos Webpay REST - transbank-sdk-php-webpay-rest-example test02](https://github.com/TransbankDevelopers/transbank-sdk-php-webpay-rest-example/assets/16402208/bc6dd2ac-7423-42c9-9194-b1301b7692af)

