### PR TITLE
fix: commerce code 3DS doesn't exist on .env

### DIFF
--- a/app/Http/Controllers/WebpayPlusMallController.php
+++ b/app/Http/Controllers/WebpayPlusMallController.php
@@ -23,11 +23,15 @@ class WebpayPlusMallController extends Controller
 
         $commerceCodeList = [];
         foreach ($childCommerceCodeNormal as $childNormal){
-            $commerceCodeList[] = ['commerce_code' => $childNormal, 'type_child'=> 'normal'];
+            if ($childNormal != ""){
+                $commerceCodeList[] = ['commerce_code' => $childNormal, 'type_child'=> 'normal'];
+            }
         }
 
         foreach ($childCommerceCode3ds as $child){
-            $commerceCodeList[] = ['commerce_code' => $child, 'type_child'=> '3DS'];
+            if($child != ""){
+                $commerceCodeList[] = ['commerce_code' => $child, 'type_child'=> '3DS'];
+            }
         }
 
         return view('webpayplus/mall_create', compact('commerceCodeList'));


### PR DESCRIPTION
This PR includes:
- Validation when child commerce code 3DS or normal doesn't exist on .env

![image](https://github.com/TransbankDevelopers/transbank-sdk-php-webpay-rest-example/assets/16402208/6b8384a7-636b-4fa9-8d77-6536fb5d2723)
