### PR TITLE
feat: improve challenge handle

### DIFF
--- a/app/Http/Controllers/OneclickStandardBrandController.php
+++ b/app/Http/Controllers/OneclickStandardBrandController.php
@@ -161,7 +161,7 @@ class OneclickStandardBrandController extends Controller
             return response()->json(['error' => 'Unable to retrieve transaction status'], 500);
         }
 
-        if (!isset($resp['details']) || !is_array($resp['details']) || empty($resp['details']) || !isset($resp['details'][0]['status'])) {
+        if (!isset($resp['details']) || !is_array($resp['details']) || empty($resp['details']) || !is_array($resp['details'][0]) || !isset($resp['details'][0]['status'])) {
             return response()->json(['error' => 'Invalid response format'], 500);
         }
 

--- a/app/Http/Controllers/OneclickStandardBrandController.php
+++ b/app/Http/Controllers/OneclickStandardBrandController.php
@@ -168,8 +168,6 @@ class OneclickStandardBrandController extends Controller
         $status = $resp['details'][0]['status'];
 
         return response()->json([
-            'buy_order' => $buyOrder,
-            'status' => $status,
             'is_initialized' => $status === 'INITIALIZED',
         ]);
     }

--- a/app/Http/Controllers/OneclickStandardBrandController.php
+++ b/app/Http/Controllers/OneclickStandardBrandController.php
@@ -168,7 +168,7 @@ class OneclickStandardBrandController extends Controller
         $status = $resp['details'][0]['status'];
 
         return response()->json([
-            'buy_order' => $resp['buy_order'] ?? $buyOrder,
+            'buy_order' => $buyOrder,
             'status' => $status,
             'is_initialized' => $status === 'INITIALIZED',
         ]);

--- a/app/Http/Controllers/OneclickStandardBrandController.php
+++ b/app/Http/Controllers/OneclickStandardBrandController.php
@@ -151,7 +151,7 @@ class OneclickStandardBrandController extends Controller
             return response()->json(['error' => 'Unable to retrieve transaction status'], 503);
         }
 
-        if (!isset($resp['details']) || !is_array($resp['details']) || !isset($resp['details'][0]['status'])) {
+        if (!isset($resp['details']) || !is_array($resp['details']) || empty($resp['details']) || !isset($resp['details'][0]['status'])) {
             return response()->json(['error' => 'Invalid response format'], 500);
         }
 

--- a/app/Http/Controllers/OneclickStandardBrandController.php
+++ b/app/Http/Controllers/OneclickStandardBrandController.php
@@ -138,6 +138,32 @@ class OneclickStandardBrandController extends Controller
         return view('oneclick/standard_brand/mall_transaction_status', ["req" => $req, "resp" => $resp]);
     }
 
+    public function pollTransactionStatus(Request $request)
+    {
+        $validated = $request->validate([
+            'buy_order' => 'required|string|max:26',
+        ]);
+        $buyOrder = $validated['buy_order'];
+
+        try {
+            $resp = $this->standardBrandService->status($buyOrder);
+        } catch (\Exception $e) {
+            return response()->json(['error' => $e->getMessage()], 502);
+        }
+
+        if (!isset($resp['details'][0]['status'])) {
+            return response()->json(['error' => 'Transaction status is not available'], 502);
+        }
+
+        $status = $resp['details'][0]['status'];
+
+        return response()->json([
+            'buy_order' => $resp['buy_order'] ?? $buyOrder,
+            'status' => $status,
+            'is_initialized' => $status === 'INITIALIZED',
+        ]);
+    }
+
     public function refund(Request $request)
     {
         $req = $request->except('_token');

--- a/app/Http/Controllers/OneclickStandardBrandController.php
+++ b/app/Http/Controllers/OneclickStandardBrandController.php
@@ -148,7 +148,17 @@ class OneclickStandardBrandController extends Controller
         try {
             $resp = $this->standardBrandService->status($buyOrder);
         } catch (\Exception $e) {
-            return response()->json(['error' => 'Unable to retrieve transaction status'], 503);
+            $statusCode = (int) $e->getCode();
+
+            if ($statusCode >= 400 && $statusCode < 500) {
+                return response()->json(['error' => 'Unable to retrieve transaction status'], 400);
+            }
+
+            if ($statusCode === 0 || $statusCode >= 500) {
+                return response()->json(['error' => 'Transaction status service unavailable'], 503);
+            }
+
+            return response()->json(['error' => 'Unable to retrieve transaction status'], 500);
         }
 
         if (!isset($resp['details']) || !is_array($resp['details']) || empty($resp['details']) || !isset($resp['details'][0]['status'])) {

--- a/app/Http/Controllers/OneclickStandardBrandController.php
+++ b/app/Http/Controllers/OneclickStandardBrandController.php
@@ -161,15 +161,32 @@ class OneclickStandardBrandController extends Controller
             return response()->json(['error' => 'Unable to retrieve transaction status'], 500);
         }
 
-        if (!isset($resp['details']) || !is_array($resp['details']) || empty($resp['details']) || !is_array($resp['details'][0]) || !isset($resp['details'][0]['status'])) {
+        $status = $this->getStatusFromResponse($resp);
+
+        if ($status === null) {
             return response()->json(['error' => 'Invalid response format'], 500);
         }
-
-        $status = $resp['details'][0]['status'];
 
         return response()->json([
             'is_initialized' => $status === 'INITIALIZED',
         ]);
+    }
+
+    private function getStatusFromResponse(array $resp): ?string
+    {
+        if (!isset($resp['details']) || !is_array($resp['details'])) {
+            return null;
+        }
+
+        if (empty($resp['details']) || !is_array($resp['details'][0])) {
+            return null;
+        }
+
+        if (!isset($resp['details'][0]['status']) || !is_string($resp['details'][0]['status'])) {
+            return null;
+        }
+
+        return $resp['details'][0]['status'];
     }
 
     public function refund(Request $request)

--- a/app/Http/Controllers/OneclickStandardBrandController.php
+++ b/app/Http/Controllers/OneclickStandardBrandController.php
@@ -148,11 +148,11 @@ class OneclickStandardBrandController extends Controller
         try {
             $resp = $this->standardBrandService->status($buyOrder);
         } catch (\Exception $e) {
-            return response()->json(['error' => $e->getMessage()], 502);
+            return response()->json(['error' => 'Unable to retrieve transaction status'], 503);
         }
 
-        if (!isset($resp['details'][0]['status'])) {
-            return response()->json(['error' => 'Transaction status is not available'], 502);
+        if (!isset($resp['details']) || !is_array($resp['details']) || !isset($resp['details'][0]['status'])) {
+            return response()->json(['error' => 'Invalid response format'], 500);
         }
 
         $status = $resp['details'][0]['status'];

--- a/resources/views/oneclick/standard_brand/authorized_mall.blade.php
+++ b/resources/views/oneclick/standard_brand/authorized_mall.blade.php
@@ -195,8 +195,16 @@
             }
 
             const statusMessage = document.getElementById('challengeStatusMessage');
-            const buyOrder = document.getElementById('challengeStatusBuyOrder').value;
-            const csrfToken = document.querySelector('#challengeStatusCheckForm input[name="_token"]').value;
+            const buyOrderInput = document.getElementById('challengeStatusBuyOrder');
+            const csrfTokenInput = document.querySelector('#challengeStatusCheckForm input[name="_token"]');
+
+            if (!buyOrderInput || !buyOrderInput.value || !csrfTokenInput || !csrfTokenInput.value) {
+                stopChallengePolling('No fue posible iniciar la consulta de status. Faltan datos requeridos en la página.');
+                return;
+            }
+
+            const buyOrder = buyOrderInput.value;
+            const csrfToken = csrfTokenInput.value;
             const pollUrl = '/oneclick/standard_brand/mall/transactionStatus/poll';
 
             try {

--- a/resources/views/oneclick/standard_brand/authorized_mall.blade.php
+++ b/resources/views/oneclick/standard_brand/authorized_mall.blade.php
@@ -163,13 +163,20 @@
 
             const statusMessage = document.getElementById('challengeStatusMessage');
             const buyOrder = document.getElementById('challengeStatusBuyOrder').value;
-            const pollUrl = `/oneclick/standard_brand/mall/transactionStatus/poll?buy_order=${encodeURIComponent(buyOrder)}`;
+            const csrfToken = document.querySelector('#challengeStatusCheckForm input[name="_token"]').value;
+            const pollUrl = '/oneclick/standard_brand/mall/transactionStatus/poll';
 
             try {
                 const response = await fetch(pollUrl, {
+                    method: 'POST',
                     headers: {
-                        'Accept': 'application/json'
-                    }
+                        'Accept': 'application/json',
+                        'Content-Type': 'application/json',
+                        'X-CSRF-TOKEN': csrfToken
+                    },
+                    body: JSON.stringify({
+                        buy_order: buyOrder
+                    })
                 });
 
                 if (!response.ok) {

--- a/resources/views/oneclick/standard_brand/authorized_mall.blade.php
+++ b/resources/views/oneclick/standard_brand/authorized_mall.blade.php
@@ -125,13 +125,22 @@
             statusMessage.textContent = message;
         }
 
+        function handleChallengePollingTimeout() {
+            if (challengeWindow && !challengeWindow.closed) {
+                challengeWindow.close();
+            }
+
+            clearChallengeMonitor();
+            submitStatusForm('Tiempo máximo de espera alcanzado. Consultando status de la autorización...');
+        }
+
         function scheduleChallengeMonitor() {
             if (challengePollingStopped || statusRequestSubmitted || !challengeWindow || challengeWindow.closed) {
                 return;
             }
 
             if (hasExceededMaxPollingDuration()) {
-                stopChallengePolling('No fue posible confirmar el status automáticamente en 10 minutos. Cierre la ventana del desafío manualmente para continuar.');
+                handleChallengePollingTimeout();
                 return;
             }
 
@@ -146,7 +155,11 @@
             consecutivePollErrors++;
 
             if (consecutivePollErrors >= challengePollMaxConsecutiveErrors) {
-                stopChallengePolling('No fue posible consultar el status automáticamente. Cierre la ventana del desafío manualmente para continuar.');
+                if (challengeWindow && !challengeWindow.closed) {
+                    challengeWindow.close();
+                }
+
+                submitStatusForm('Consultando status de la autorización...');
                 return;
             }
 
@@ -220,7 +233,7 @@
             }
 
             if (hasExceededMaxPollingDuration()) {
-                stopChallengePolling('No fue posible confirmar el status automáticamente en 10 minutos. Cierre la ventana del desafío manualmente para continuar.');
+                handleChallengePollingTimeout();
                 return;
             }
 

--- a/resources/views/oneclick/standard_brand/authorized_mall.blade.php
+++ b/resources/views/oneclick/standard_brand/authorized_mall.blade.php
@@ -235,7 +235,14 @@
                     return;
                 }
 
-                const data = await response.json();
+                let data = null;
+
+                try {
+                    data = await response.json();
+                } catch (error) {
+                    registerPollFailure('Error al procesar respuesta del servidor.');
+                    return;
+                }
 
                 if (shouldStopPollingResultHandling()) {
                     return;

--- a/resources/views/oneclick/standard_brand/authorized_mall.blade.php
+++ b/resources/views/oneclick/standard_brand/authorized_mall.blade.php
@@ -71,7 +71,7 @@
     <script>
         let challengeWindow = null;
         let challengeMonitorTimeoutId = null;
-        let challengeStatusPollInProgress = false;
+        let challengeStatusPollPromise = null;
         let statusRequestSubmitted = false;
         let challengePollingStopped = false;
         let challengeStartedAt = null;
@@ -173,11 +173,9 @@
         }
 
         async function pollChallengeStatus() {
-            if (challengeStatusPollInProgress || statusRequestSubmitted || challengePollingStopped) {
+            if (challengeStatusPollPromise || statusRequestSubmitted || challengePollingStopped) {
                 return;
             }
-
-            challengeStatusPollInProgress = true;
 
             const statusMessage = document.getElementById('challengeStatusMessage');
             const buyOrder = document.getElementById('challengeStatusBuyOrder').value;
@@ -185,7 +183,7 @@
             const pollUrl = '/oneclick/standard_brand/mall/transactionStatus/poll';
 
             try {
-                const response = await fetch(pollUrl, {
+                challengeStatusPollPromise = fetch(pollUrl, {
                     method: 'POST',
                     headers: {
                         'Accept': 'application/json',
@@ -196,6 +194,8 @@
                         buy_order: buyOrder
                     })
                 });
+
+                const response = await challengeStatusPollPromise;
 
                 if (!response.ok) {
                     registerPollFailure('No fue posible consultar el status.');
@@ -224,7 +224,7 @@
             } catch (error) {
                 registerPollFailure('No fue posible consultar el status.');
             } finally {
-                challengeStatusPollInProgress = false;
+                challengeStatusPollPromise = null;
                 scheduleChallengeMonitor();
             }
         }

--- a/resources/views/oneclick/standard_brand/authorized_mall.blade.php
+++ b/resources/views/oneclick/standard_brand/authorized_mall.blade.php
@@ -189,6 +189,10 @@
             document.getElementById('challengeStatusMessage').textContent = `No fue posible conectar para consultar el status. Revisa tu conexión. Se reintentará en ${nextRetrySeconds} segundos.`;
         }
 
+        function shouldStopPollingResultHandling() {
+            return statusRequestSubmitted || challengePollingStopped || !challengeWindow || challengeWindow.closed;
+        }
+
         async function pollChallengeStatus() {
             if (challengeStatusPollPromise || statusRequestSubmitted || challengePollingStopped) {
                 return;
@@ -222,12 +226,20 @@
 
                 const response = await challengeStatusPollPromise;
 
+                if (shouldStopPollingResultHandling()) {
+                    return;
+                }
+
                 if (!response.ok) {
                     registerPollFailure('No fue posible consultar el status.');
                     return;
                 }
 
                 const data = await response.json();
+
+                if (shouldStopPollingResultHandling()) {
+                    return;
+                }
 
                 if (!data || typeof data.is_initialized !== 'boolean') {
                     registerPollFailure('Respuesta inválida del servidor.');

--- a/resources/views/oneclick/standard_brand/authorized_mall.blade.php
+++ b/resources/views/oneclick/standard_brand/authorized_mall.blade.php
@@ -140,7 +140,12 @@
         }
 
         function scheduleChallengeMonitor() {
-            if (challengePollingStopped || statusRequestSubmitted || !challengeWindow || challengeWindow.closed) {
+            if (challengePollingStopped || statusRequestSubmitted || !challengeWindow) {
+                return;
+            }
+
+            if (challengeWindow.closed) {
+                submitStatusForm('Desafío terminado. Consultando status de la autorización...');
                 return;
             }
 

--- a/resources/views/oneclick/standard_brand/authorized_mall.blade.php
+++ b/resources/views/oneclick/standard_brand/authorized_mall.blade.php
@@ -281,7 +281,18 @@
             updateChallengeWindowState();
         }
 
+        function cleanupChallengeFlow() {
+            challengePollingStopped = true;
+            clearChallengeMonitor();
+
+            if (challengeWindow && !challengeWindow.closed) {
+                challengeWindow.close();
+            }
+        }
+
         document.getElementById('openChallengeButton').addEventListener('click', openChallengeFlow);
+        window.addEventListener('beforeunload', cleanupChallengeFlow);
+        window.addEventListener('pagehide', cleanupChallengeFlow);
     </script>
 
 @endif

--- a/resources/views/oneclick/standard_brand/authorized_mall.blade.php
+++ b/resources/views/oneclick/standard_brand/authorized_mall.blade.php
@@ -89,17 +89,19 @@
         }
 
         function submitStatusForm(message) {
+            if (statusRequestSubmitted) {
+                return;
+            }
+
+            statusRequestSubmitted = true;
+
             const statusMessage = document.getElementById('challengeStatusMessage');
             const statusCheckForm = document.getElementById('challengeStatusCheckForm');
 
             statusMessage.textContent = message;
 
             clearChallengeMonitor();
-
-            if (!statusRequestSubmitted) {
-                statusRequestSubmitted = true;
-                statusCheckForm.submit();
-            }
+            statusCheckForm.submit();
         }
 
         function getNextPollDelay() {
@@ -148,7 +150,10 @@
             const delayMs = Math.min(getNextPollDelay(), remainingDurationMs);
 
             clearChallengeMonitor();
-            challengeMonitorTimeoutId = window.setTimeout(updateChallengeWindowState, delayMs);
+            challengeMonitorTimeoutId = window.setTimeout(() => {
+                challengeMonitorTimeoutId = null;
+                updateChallengeWindowState();
+            }, delayMs);
         }
 
         function registerPollFailure(message) {
@@ -247,6 +252,12 @@
 
         function openChallengeFlow() {
             challengeWindow = window.open('', 'challengeWindow', 'width=520,height=720,resizable=yes,scrollbars=yes');
+
+            if (!challengeWindow || challengeWindow.closed) {
+                document.getElementById('challengeStatusMessage').textContent = 'No fue posible abrir la ventana del desafío. Habilita los popups e intenta nuevamente.';
+                return;
+            }
+
             challengePollingStopped = false;
             challengeStartedAt = Date.now();
             consecutivePollErrors = 0;

--- a/resources/views/oneclick/standard_brand/authorized_mall.blade.php
+++ b/resources/views/oneclick/standard_brand/authorized_mall.blade.php
@@ -81,6 +81,7 @@
         const challengePollMaxBackoffMs = 30000;
         const challengePollMaxDurationMs = 10 * 60 * 1000;
         const challengePollMaxConsecutiveErrors = 10;
+        const challengePollRequestTimeoutMs = 15000;
 
         function clearChallengeMonitor() {
             if (challengeMonitorTimeoutId) {
@@ -210,6 +211,8 @@
             const buyOrder = buyOrderInput.value;
             const csrfToken = csrfTokenInput.value;
             const pollUrl = '/oneclick/standard_brand/mall/transactionStatus/poll';
+            const controller = new AbortController();
+            const requestTimeoutId = window.setTimeout(() => controller.abort(), challengePollRequestTimeoutMs);
 
             try {
                 challengeStatusPollPromise = fetch(pollUrl, {
@@ -221,7 +224,8 @@
                     },
                     body: JSON.stringify({
                         buy_order: buyOrder
-                    })
+                    }),
+                    signal: controller.signal
                 });
 
                 const response = await challengeStatusPollPromise;
@@ -269,6 +273,7 @@
             } catch (error) {
                 registerNetworkFailure();
             } finally {
+                clearTimeout(requestTimeoutId);
                 challengeStatusPollPromise = null;
                 scheduleChallengeMonitor();
             }

--- a/resources/views/oneclick/standard_brand/authorized_mall.blade.php
+++ b/resources/views/oneclick/standard_brand/authorized_mall.blade.php
@@ -70,9 +70,23 @@
 
     <script>
         let challengeWindow = null;
-        let challengeMonitorIntervalId = null;
+        let challengeMonitorTimeoutId = null;
         let challengeStatusPollInProgress = false;
         let statusRequestSubmitted = false;
+        let challengePollingStopped = false;
+        let challengeStartedAt = null;
+        let consecutivePollErrors = 0;
+        const challengePollBaseDelayMs = 3000;
+        const challengePollMaxBackoffMs = 30000;
+        const challengePollMaxDurationMs = 10 * 60 * 1000;
+        const challengePollMaxConsecutiveErrors = 10;
+
+        function clearChallengeMonitor() {
+            if (challengeMonitorTimeoutId) {
+                clearTimeout(challengeMonitorTimeoutId);
+                challengeMonitorTimeoutId = null;
+            }
+        }
 
         function submitStatusForm(message) {
             const statusMessage = document.getElementById('challengeStatusMessage');
@@ -80,10 +94,7 @@
 
             statusMessage.textContent = message;
 
-            if (challengeMonitorIntervalId) {
-                clearInterval(challengeMonitorIntervalId);
-                challengeMonitorIntervalId = null;
-            }
+            clearChallengeMonitor();
 
             if (!statusRequestSubmitted) {
                 statusRequestSubmitted = true;
@@ -91,8 +102,60 @@
             }
         }
 
+        function getNextPollDelay() {
+            if (consecutivePollErrors === 0) {
+                return challengePollBaseDelayMs;
+            }
+
+            return Math.min(
+                challengePollBaseDelayMs * Math.pow(2, consecutivePollErrors - 1),
+                challengePollMaxBackoffMs
+            );
+        }
+
+        function hasExceededMaxPollingDuration() {
+            return challengeStartedAt && Date.now() - challengeStartedAt >= challengePollMaxDurationMs;
+        }
+
+        function stopChallengePolling(message) {
+            const statusMessage = document.getElementById('challengeStatusMessage');
+
+            challengePollingStopped = true;
+            clearChallengeMonitor();
+            statusMessage.textContent = message;
+        }
+
+        function scheduleChallengeMonitor() {
+            if (challengePollingStopped || statusRequestSubmitted || !challengeWindow || challengeWindow.closed) {
+                return;
+            }
+
+            if (hasExceededMaxPollingDuration()) {
+                stopChallengePolling('No fue posible confirmar el status automáticamente en 10 minutos. Cierre la ventana del desafío manualmente para continuar.');
+                return;
+            }
+
+            const remainingDurationMs = challengePollMaxDurationMs - (Date.now() - challengeStartedAt);
+            const delayMs = Math.min(getNextPollDelay(), remainingDurationMs);
+
+            clearChallengeMonitor();
+            challengeMonitorTimeoutId = window.setTimeout(updateChallengeWindowState, delayMs);
+        }
+
+        function registerPollFailure(message) {
+            consecutivePollErrors++;
+
+            if (consecutivePollErrors >= challengePollMaxConsecutiveErrors) {
+                stopChallengePolling('No fue posible consultar el status automáticamente. Cierre la ventana del desafío manualmente para continuar.');
+                return;
+            }
+
+            const nextRetrySeconds = Math.ceil(getNextPollDelay() / 1000);
+            document.getElementById('challengeStatusMessage').textContent = `${message} Se reintentará en ${nextRetrySeconds} segundos.`;
+        }
+
         async function pollChallengeStatus() {
-            if (challengeStatusPollInProgress || statusRequestSubmitted) {
+            if (challengeStatusPollInProgress || statusRequestSubmitted || challengePollingStopped) {
                 return;
             }
 
@@ -110,11 +173,18 @@
                 });
 
                 if (!response.ok) {
-                    statusMessage.textContent = 'No fue posible consultar el status. Se reintentará en unos segundos.';
+                    registerPollFailure('No fue posible consultar el status.');
                     return;
                 }
 
                 const data = await response.json();
+
+                if (!data || typeof data.is_initialized !== 'boolean') {
+                    registerPollFailure('Respuesta inválida del servidor.');
+                    return;
+                }
+
+                consecutivePollErrors = 0;
 
                 if (!data.is_initialized) {
                     if (challengeWindow && !challengeWindow.closed) {
@@ -127,9 +197,10 @@
 
                 statusMessage.textContent = 'La ventana del desafío sigue abierta. Status actual: INITIALIZED.';
             } catch (error) {
-                statusMessage.textContent = 'No fue posible consultar el status. Se reintentará en unos segundos.';
+                registerPollFailure('No fue posible consultar el status.');
             } finally {
                 challengeStatusPollInProgress = false;
+                scheduleChallengeMonitor();
             }
         }
 
@@ -138,6 +209,11 @@
 
             if (!challengeWindow) {
                 statusMessage.textContent = 'Aún no se ha abierto la ventana del desafío.';
+                return;
+            }
+
+            if (hasExceededMaxPollingDuration()) {
+                stopChallengePolling('No fue posible confirmar el status automáticamente en 10 minutos. Cierre la ventana del desafío manualmente para continuar.');
                 return;
             }
 
@@ -151,14 +227,13 @@
 
         function openChallengeFlow() {
             challengeWindow = window.open('', 'challengeWindow', 'width=520,height=720,resizable=yes,scrollbars=yes');
+            challengePollingStopped = false;
+            challengeStartedAt = Date.now();
+            consecutivePollErrors = 0;
 
             document.getElementById('challengePopupForm').submit();
 
             updateChallengeWindowState();
-
-            if (!challengeMonitorIntervalId) {
-                challengeMonitorIntervalId = window.setInterval(updateChallengeWindowState,3000);
-            }
         }
 
         document.getElementById('openChallengeButton').addEventListener('click', openChallengeFlow);

--- a/resources/views/oneclick/standard_brand/authorized_mall.blade.php
+++ b/resources/views/oneclick/standard_brand/authorized_mall.blade.php
@@ -64,18 +64,77 @@
         @csrf
     </form>
 
-    <button type="button" onclick="openChallengeFlow()">
+    <button type="button" id="openChallengeButton">
         Abrir desafío
     </button>
 
     <script>
         let challengeWindow = null;
         let challengeMonitorIntervalId = null;
+        let challengeStatusPollInProgress = false;
         let statusRequestSubmitted = false;
+
+        function submitStatusForm(message) {
+            const statusMessage = document.getElementById('challengeStatusMessage');
+            const statusCheckForm = document.getElementById('challengeStatusCheckForm');
+
+            statusMessage.textContent = message;
+
+            if (challengeMonitorIntervalId) {
+                clearInterval(challengeMonitorIntervalId);
+                challengeMonitorIntervalId = null;
+            }
+
+            if (!statusRequestSubmitted) {
+                statusRequestSubmitted = true;
+                statusCheckForm.submit();
+            }
+        }
+
+        async function pollChallengeStatus() {
+            if (challengeStatusPollInProgress || statusRequestSubmitted) {
+                return;
+            }
+
+            challengeStatusPollInProgress = true;
+
+            const statusMessage = document.getElementById('challengeStatusMessage');
+            const buyOrder = document.getElementById('challengeStatusBuyOrder').value;
+            const pollUrl = `/oneclick/standard_brand/mall/transactionStatus/poll?buy_order=${encodeURIComponent(buyOrder)}`;
+
+            try {
+                const response = await fetch(pollUrl, {
+                    headers: {
+                        'Accept': 'application/json'
+                    }
+                });
+
+                if (!response.ok) {
+                    statusMessage.textContent = 'No fue posible consultar el status. Se reintentará en unos segundos.';
+                    return;
+                }
+
+                const data = await response.json();
+
+                if (!data.is_initialized) {
+                    if (challengeWindow && !challengeWindow.closed) {
+                        challengeWindow.close();
+                    }
+
+                    submitStatusForm('Autorización actualizada. Consultando status de la autorización...');
+                    return;
+                }
+
+                statusMessage.textContent = 'La ventana del desafío sigue abierta. Status actual: INITIALIZED.';
+            } catch (error) {
+                statusMessage.textContent = 'No fue posible consultar el status. Se reintentará en unos segundos.';
+            } finally {
+                challengeStatusPollInProgress = false;
+            }
+        }
 
         function updateChallengeWindowState() {
             const statusMessage = document.getElementById('challengeStatusMessage');
-            const statusCheckForm = document.getElementById('challengeStatusCheckForm');
 
             if (!challengeWindow) {
                 statusMessage.textContent = 'Aún no se ha abierto la ventana del desafío.';
@@ -83,22 +142,11 @@
             }
 
             if (challengeWindow.closed) {
-                statusMessage.textContent = 'Desafío terminado. Consultando status de la autorización...';
-
-                if (challengeMonitorIntervalId) {
-                    clearInterval(challengeMonitorIntervalId);
-                    challengeMonitorIntervalId = null;
-                }
-
-                if (!statusRequestSubmitted) {
-                    statusRequestSubmitted = true;
-                    statusCheckForm.submit();
-                }
-
+                submitStatusForm('Desafío terminado. Consultando status de la autorización...');
                 return;
             }
 
-            statusMessage.textContent = 'La ventana del desafío sigue abierta.';
+            pollChallengeStatus();
         }
 
         function openChallengeFlow() {
@@ -109,9 +157,11 @@
             updateChallengeWindowState();
 
             if (!challengeMonitorIntervalId) {
-                challengeMonitorIntervalId = window.setInterval(updateChallengeWindowState, 3000);
+                challengeMonitorIntervalId = window.setInterval(updateChallengeWindowState,3000);
             }
         }
+
+        document.getElementById('openChallengeButton').addEventListener('click', openChallengeFlow);
     </script>
 
 @endif

--- a/resources/views/oneclick/standard_brand/authorized_mall.blade.php
+++ b/resources/views/oneclick/standard_brand/authorized_mall.blade.php
@@ -76,6 +76,7 @@
         let challengePollingStopped = false;
         let challengeStartedAt = null;
         let consecutivePollErrors = 0;
+        let consecutiveNetworkErrors = 0;
         const challengePollBaseDelayMs = 3000;
         const challengePollMaxBackoffMs = 30000;
         const challengePollMaxDurationMs = 10 * 60 * 1000;
@@ -105,12 +106,14 @@
         }
 
         function getNextPollDelay() {
-            if (consecutivePollErrors === 0) {
+            const consecutiveErrors = Math.max(consecutivePollErrors, consecutiveNetworkErrors);
+
+            if (consecutiveErrors === 0) {
                 return challengePollBaseDelayMs;
             }
 
             return Math.min(
-                challengePollBaseDelayMs * Math.pow(2, consecutivePollErrors - 1),
+                challengePollBaseDelayMs * Math.pow(2, consecutiveErrors - 1),
                 challengePollMaxBackoffMs
             );
         }
@@ -158,6 +161,7 @@
 
         function registerPollFailure(message) {
             consecutivePollErrors++;
+            consecutiveNetworkErrors = 0;
 
             if (consecutivePollErrors >= challengePollMaxConsecutiveErrors) {
                 if (challengeWindow && !challengeWindow.closed) {
@@ -170,6 +174,14 @@
 
             const nextRetrySeconds = Math.ceil(getNextPollDelay() / 1000);
             document.getElementById('challengeStatusMessage').textContent = `${message} Se reintentará en ${nextRetrySeconds} segundos.`;
+        }
+
+        function registerNetworkFailure() {
+            consecutiveNetworkErrors++;
+            consecutivePollErrors = 0;
+
+            const nextRetrySeconds = Math.ceil(getNextPollDelay() / 1000);
+            document.getElementById('challengeStatusMessage').textContent = `No fue posible conectar para consultar el status. Revisa tu conexión. Se reintentará en ${nextRetrySeconds} segundos.`;
         }
 
         async function pollChallengeStatus() {
@@ -210,6 +222,7 @@
                 }
 
                 consecutivePollErrors = 0;
+                consecutiveNetworkErrors = 0;
 
                 if (!data.is_initialized) {
                     if (challengeWindow && !challengeWindow.closed) {
@@ -222,7 +235,7 @@
 
                 statusMessage.textContent = 'La ventana del desafío sigue abierta. Status actual: INITIALIZED.';
             } catch (error) {
-                registerPollFailure('No fue posible consultar el status.');
+                registerNetworkFailure();
             } finally {
                 challengeStatusPollPromise = null;
                 scheduleChallengeMonitor();
@@ -261,6 +274,7 @@
             challengePollingStopped = false;
             challengeStartedAt = Date.now();
             consecutivePollErrors = 0;
+            consecutiveNetworkErrors = 0;
 
             document.getElementById('challengePopupForm').submit();
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -282,7 +282,7 @@ Route::middleware(['auth'])->group(function () {
         Route::get('/mall/direct-authorize', 'OneclickStandardBrandController@showDirectAuthorize');
         Route::post('/mall/challenge-popup', 'OneclickStandardBrandController@showChallengePopup');
         Route::post('/mall/authorizeTransaction', 'OneclickStandardBrandController@authorizeMall');
-        Route::post('/mall/transactionStatus/poll', 'OneclickStandardBrandController@pollTransactionStatus');
+        Route::post('/mall/transactionStatus/poll', 'OneclickStandardBrandController@pollTransactionStatus')->middleware('throttle:60,1');
         Route::post('/mall/transactionStatus', 'OneclickStandardBrandController@transactionStatus');
         Route::post('/mall/refund', 'OneclickStandardBrandController@refund');
     });

--- a/routes/web.php
+++ b/routes/web.php
@@ -282,7 +282,7 @@ Route::middleware(['auth'])->group(function () {
         Route::get('/mall/direct-authorize', 'OneclickStandardBrandController@showDirectAuthorize');
         Route::post('/mall/challenge-popup', 'OneclickStandardBrandController@showChallengePopup');
         Route::post('/mall/authorizeTransaction', 'OneclickStandardBrandController@authorizeMall');
-        Route::get('/mall/transactionStatus/poll', 'OneclickStandardBrandController@pollTransactionStatus');
+        Route::post('/mall/transactionStatus/poll', 'OneclickStandardBrandController@pollTransactionStatus');
         Route::post('/mall/transactionStatus', 'OneclickStandardBrandController@transactionStatus');
         Route::post('/mall/refund', 'OneclickStandardBrandController@refund');
     });

--- a/routes/web.php
+++ b/routes/web.php
@@ -282,6 +282,7 @@ Route::middleware(['auth'])->group(function () {
         Route::get('/mall/direct-authorize', 'OneclickStandardBrandController@showDirectAuthorize');
         Route::post('/mall/challenge-popup', 'OneclickStandardBrandController@showChallengePopup');
         Route::post('/mall/authorizeTransaction', 'OneclickStandardBrandController@authorizeMall');
+        Route::get('/mall/transactionStatus/poll', 'OneclickStandardBrandController@pollTransactionStatus');
         Route::post('/mall/transactionStatus', 'OneclickStandardBrandController@transactionStatus');
         Route::post('/mall/refund', 'OneclickStandardBrandController@refund');
     });

--- a/routes/web.php
+++ b/routes/web.php
@@ -282,7 +282,7 @@ Route::middleware(['auth'])->group(function () {
         Route::get('/mall/direct-authorize', 'OneclickStandardBrandController@showDirectAuthorize');
         Route::post('/mall/challenge-popup', 'OneclickStandardBrandController@showChallengePopup');
         Route::post('/mall/authorizeTransaction', 'OneclickStandardBrandController@authorizeMall');
-        Route::post('/mall/transactionStatus/poll', 'OneclickStandardBrandController@pollTransactionStatus')->middleware('throttle:60,1');
+        Route::post('/mall/transactionStatus/poll', 'OneclickStandardBrandController@pollTransactionStatus')->middleware('throttle:30,1');
         Route::post('/mall/transactionStatus', 'OneclickStandardBrandController@transactionStatus');
         Route::post('/mall/refund', 'OneclickStandardBrandController@refund');
     });


### PR DESCRIPTION
This PR improves the Oneclick Mall Standard Brand 3DS challenge flow by adding a transaction status polling mechanism while the challenge popup is open.

When a challenge is required, the page now periodically checks the transaction status. If the status changes from `INITIALIZED`, the challenge popup is closed automatically and the user is redirected to the existing transaction status screen. If the user manually closes the popup before the status changes, the previous behavior is preserved.

## Changes

- Added a new JSON polling endpoint:
  - `GET /oneclick/standard_brand/mall/transactionStatus/poll`
- Added `pollTransactionStatus()` to validate `buy_order`, query the current transaction status, and return:
  - `buy_order`
  - `status`
  - `is_initialized`
- Updated the challenge view to:
  - Poll the transaction status every 3 seconds while the popup is open
  - Close the popup automatically when the status is no longer `INITIALIZED`
  - Continue to the existing status page flow after completion
  - Preserve the manual popup close behavior