### PR TITLE
fix: add missing fields in authorization response

### DIFF
--- a/app/Dto/OneclickStandardBrand/TransactionDetailsDTO.php
+++ b/app/Dto/OneclickStandardBrand/TransactionDetailsDTO.php
@@ -12,6 +12,12 @@ class TransactionDetailsDTO
     private $status;
 
     /** @var string */
+    private $glosa;
+
+    /** @var string */
+    private $responseCodeReference;
+
+    /** @var string */
     private $tid;
 
     /** @var string */
@@ -41,6 +47,8 @@ class TransactionDetailsDTO
     public function __construct(
         $amount,
         string $status,
+        string $glosa,
+        string $responseCodeReference,
         string $tid,
         string $authorizationCode,
         string $paymentTypeCode,
@@ -53,6 +61,8 @@ class TransactionDetailsDTO
     ) {
         $this->amount = $amount;
         $this->status = $status;
+        $this->glosa = $glosa;
+        $this->responseCodeReference = $responseCodeReference;
         $this->tid = $tid;
         $this->authorizationCode = $authorizationCode;
         $this->paymentTypeCode = $paymentTypeCode;
@@ -69,6 +79,8 @@ class TransactionDetailsDTO
         return new self(
             $data['amount'],
             $data['status'],
+            $data['glosa'],
+            $data['response_code_reference'],
             $data['tid'],
             $data['authorization_code'],
             $data['payment_type_code'],
@@ -89,6 +101,16 @@ class TransactionDetailsDTO
     public function getStatus(): string
     {
         return $this->status;
+    }
+
+    public function getGlosa(): string
+    {
+        return $this->glosa;
+    }
+
+    public function getResponseCodeReference(): string
+    {
+        return $this->responseCodeReference;
     }
 
     public function getTid(): string

--- a/app/Dto/OneclickStandardBrand/TransactionDetailsDTO.php
+++ b/app/Dto/OneclickStandardBrand/TransactionDetailsDTO.php
@@ -11,10 +11,10 @@ class TransactionDetailsDTO
     /** @var string */
     private $status;
 
-    /** @var string */
+    /** @var string|null */
     private $glosa;
 
-    /** @var string */
+    /** @var string|null */
     private $responseCodeReference;
 
     /** @var string */
@@ -47,8 +47,8 @@ class TransactionDetailsDTO
     public function __construct(
         $amount,
         string $status,
-        string $glosa,
-        string $responseCodeReference,
+        ?string $glosa,
+        ?string $responseCodeReference,
         string $tid,
         string $authorizationCode,
         string $paymentTypeCode,
@@ -79,8 +79,8 @@ class TransactionDetailsDTO
         return new self(
             $data['amount'],
             $data['status'],
-            $data['glosa'],
-            $data['response_code_reference'],
+            $data['glosa'] ?? null,
+            $data['response_code_reference'] ?? null,
             $data['tid'],
             $data['authorization_code'],
             $data['payment_type_code'],
@@ -103,12 +103,12 @@ class TransactionDetailsDTO
         return $this->status;
     }
 
-    public function getGlosa(): string
+    public function getGlosa(): ?string
     {
         return $this->glosa;
     }
 
-    public function getResponseCodeReference(): string
+    public function getResponseCodeReference(): ?string
     {
         return $this->responseCodeReference;
     }

--- a/app/Dto/OneclickStandardBrand/TransactionDetailsDTO.php
+++ b/app/Dto/OneclickStandardBrand/TransactionDetailsDTO.php
@@ -44,7 +44,7 @@ class TransactionDetailsDTO
     /** @var string */
     private $pmntInd;
 
-    public function __construct(
+    private function __construct(
         $amount,
         string $status,
         ?string $glosa,


### PR DESCRIPTION
This PR added **glosa** and **response_code_reference** to the Oneclick Standard Brand authorization detail DTO, mapping both fields from the API response and exposing them through dedicated getters.